### PR TITLE
Replace Markdown Editor Dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "@testing-library/user-event": "^12.1.10",
     "axios": "^0.21.4",
     "d3": "5.16.0",
+    "easymde": "2.17.0",
     "jsonwebtoken": "^8.5.1",
     "node-sass": "^6.0.1",
     "protvista-uniprot": "^2.7.6",
@@ -22,7 +23,6 @@
     "react-scripts": "4.0.3",
     "react-select": "^5.0.0",
     "react-spinners": "^0.11.0",
-    "simplemde": "^1.11.2",
     "uuid": "^8.3.2",
     "web-vitals": "^1.0.1"
   },

--- a/src/ui/Unmapped.jsx
+++ b/src/ui/Unmapped.jsx
@@ -12,7 +12,7 @@ import StatusText from "./components/status/StatusText";
 import { statusesList } from "./util/util";
 
 import "../styles/Unmapped.scss";
-import "../../node_modules/simplemde/dist/simplemde.min.css";
+import "../../node_modules/easymde/dist/easymde.min.css";
 
 class Unmapped extends Component {
   defaultState = {

--- a/src/ui/components/comments/CommentsAndStatusModal.jsx
+++ b/src/ui/components/comments/CommentsAndStatusModal.jsx
@@ -4,10 +4,10 @@ import PropTypes from "prop-types";
 import axios from "axios";
 import { withCookies } from "react-cookie";
 import ReactModal from "react-modal";
-import SimpleMDE from "simplemde";
+import EasyMDE from "easymde";
 
 import SendNotificationUI from "../SendNotificationUI";
-import "../../../../node_modules/simplemde/dist/simplemde.min.css";
+import "../../../../node_modules/easymde/dist/easymde.min.css";
 import "../../../styles/CommentsAndStatusModal.scss";
 
 ReactModal.setAppElement("#root");
@@ -99,7 +99,7 @@ const CommentsAndStatusModal = ({
 
   const textEditorRef = useCallback(() => {
     if (textEditorRef.current !== null) {
-      const textEditor = new SimpleMDE({
+      const textEditor = new EasyMDE({
         element: textEditorRef.current,
         initialValue: localStorage.getItem(createId(id)) || "",
         hideIcons: ["image"],


### PR DESCRIPTION
Replacing `simplemde` with `easymde` to fix the following error when trying to deploy the app
```
$ yarn run start                 
yarn run v1.22.19
$ PORT=39093 react-scripts start
ℹ ｢wds｣: Project is running at http://192.168.0.76/
ℹ ｢wds｣: webpack output is served from /gifts
ℹ ｢wds｣: Content not from webpack is served from /Users/bilal/git/gifts-curation-tool/public
ℹ ｢wds｣: 404s will fallback to /gifts/
Starting the development server...
Failed to compile.

./node_modules/simplemde/src/js/simplemde.js
Module not found: Can't resolve 'codemirror/addon/display/fullscreen.js' in '/Users/bilal/git/gifts-curation-tool/node_modules/simplemde/src/js'
Compiling...
Failed to compile.

./node_modules/simplemde/src/js/simplemde.js
Module not found: Can't resolve 'codemirror/addon/display/fullscreen.js' in '/Users/bilal/git/gifts-curation-tool/node_modules/simplemde/src/js'
```