### PR TITLE
Use noreferrer - Security recommendation

### DIFF
--- a/src/ui/components/Header.jsx
+++ b/src/ui/components/Header.jsx
@@ -65,7 +65,7 @@ function Header(props) {
               </li>
               <li>
                  <a
-                  href={`${process.env.REACT_APP_API_URL}/docs/`} target="_blank"
+                  href={`${process.env.REACT_APP_API_URL}/docs/`} rel="noreferrer" target="_blank"
                 >
                   Documentation
                 </a>


### PR DESCRIPTION
https://mathiasbynens.github.io/rel-noopener/#recommendations

GitLab pipeline fails with 

"Line 67:18:  Using target="_blank" without rel="noreferrer" (which implies rel="noopener") is a security risk in older browsers: see https://mathiasbynens.github.io/rel-noopener/#recommendations  react/jsx-no-target-blank
error Command failed with exit code 1."