### PR TITLE
Attempt to Pin Dependencies

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -15,7 +15,6 @@ build_static_assets_staging:
   only:
     refs:
       - master
-      - fix-dependencies
   extends: .js
   stage: build_static_assets_staging
   script:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -15,6 +15,7 @@ build_static_assets_staging:
   only:
     refs:
       - master
+      - fix-dependencies
   extends: .js
   stage: build_static_assets_staging
   script:

--- a/package.json
+++ b/package.json
@@ -54,5 +54,10 @@
   },
   "devDependencies": {
     "env-cmd": "^10.1.0"
+  },
+  "resolutions": {
+    "**/expect": "29.7.0",
+    "**/pretty-format": "29.7.0",
+    "**/minimatch": "^9.0.4"
   }
 }


### PR DESCRIPTION
GitLab CI/CD [job](https://gitlab.ebi.ac.uk/uniprot/front-end/gifts-curation-tool/-/jobs/2229472) is failing with the following error:
> error expect@30.2.0: The engine "node" is incompatible with this module. Expected version "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0". Got "16.20.2"
error Found incompatible module.
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.

This is an attempt to pin/downgrade the dependencies hoping to fix the issue